### PR TITLE
fix: package json main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "babel-plugin-import-directory",
   "version": "1.0.1",
   "description": "`import` directories without index.js",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "ava",
     "test:watch": "yarn test -- --watch",


### PR DESCRIPTION
The main entry is pointing to `lib/index.js` which does not exist. This commit updates the main entry to the existing path `src/index.js`.