### PR TITLE
Add the ability to include typescript files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # babel-plugin-import-directory
 
+What's new on this fork ?
+=> Include typescript files (.ts) automatically
+
 ![npm](https://img.shields.io/npm/v/babel-plugin-import-directory.svg) ![license](https://img.shields.io/npm/l/babel-plugin-import-directory.svg) ![github-issues](https://img.shields.io/github/issues/Anmo/babel-plugin-import-directory.svg)
 
 Are you sick and tired of writing an `index.js` file, just to import/export all the other files in a directory?

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const toCamelCase = (name) =>
 const toSnakeCase = (name) =>
   name.replace(/([-.A-Z])/g, (_, $1) => '_' + ($1 === '.' || $1 === '-' ? '' : $1.toLowerCase()))
 
-const getFiles = (parent, exts = ['.js', '.es6', '.es', '.jsx'], files = [], recursive = false, path = []) => {
+const getFiles = (parent, exts = ['.js', '.es6', '.es', '.jsx', '.ts'], files = [], recursive = false, path = []) => {
   let r = _fs.readdirSync(parent)
 
   for (let i = 0, l = r.length; i < l; i++) {


### PR DESCRIPTION
I required this plugin but I use typescript.
If I use the wildcard plugins, it's not working since the import will add the .ts at the end of the import which indeed does not exist on my dist folder.
By adding "manually" .ts files as "core extension", the include works perfectly.

If this is not wanted, maybe fix the ability to include other extension file without adding the extension to the import...